### PR TITLE
Various fixes in topic/tag_registration

### DIFF
--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -448,6 +448,15 @@ void* remote_dep_dequeue_main(parsec_context_t* context)
         /* acknowledge the activation */
         parsec_communication_engine_up = 3;
 
+        /* Check that we have the right memory pool pointers and update them if needed */
+        if( parsec_comm_es.context_mempool != &(parsec_comm_es.virtual_process->context_mempool.thread_mempools[0]) ) {
+            parsec_comm_es.context_mempool = &(parsec_comm_es.virtual_process->context_mempool.thread_mempools[0]);
+            for(int pi = 0; pi <= MAX_PARAM_COUNT; pi++) {
+                parsec_comm_es.datarepo_mempools[pi] = &(parsec_comm_es.virtual_process->datarepo_mempools[pi].thread_mempools[0]);
+            }
+            parsec_comm_es.dependencies_mempool = &(parsec_comm_es.virtual_process->dependencies_mempool.thread_mempools[0]);
+        }
+
         whatsup = remote_dep_dequeue_nothread_progress(&parsec_comm_es, -1 /* loop till explicitly asked to return */);
         PARSEC_DEBUG_VERBOSE(20, parsec_comm_output_stream, "MPI: comm engine OFF on process %d/%d",
                              context->my_rank, context->nb_nodes);

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -2178,7 +2178,7 @@ int remote_dep_ce_fini(parsec_context_t* context)
         PARSEC_OBJ_DESTRUCT(&dep_activates_noobj_fifo);
         PARSEC_OBJ_DESTRUCT(&dep_put_fifo);
     }
-    
+
     return 0;
 }
 

--- a/parsec/remote_dep_mpi.c
+++ b/parsec/remote_dep_mpi.c
@@ -2164,10 +2164,12 @@ int remote_dep_ce_fini(parsec_context_t* context)
         parsec_mpi_same_pos_items_size = 0;
     }
 
-    PARSEC_OBJ_DESTRUCT(&dep_activates_fifo);
-    PARSEC_OBJ_DESTRUCT(&dep_activates_noobj_fifo);
-    PARSEC_OBJ_DESTRUCT(&dep_put_fifo);
-
+    if( NULL != parsec_ce.send_am ) {
+        PARSEC_OBJ_DESTRUCT(&dep_activates_fifo);
+        PARSEC_OBJ_DESTRUCT(&dep_activates_noobj_fifo);
+        PARSEC_OBJ_DESTRUCT(&dep_put_fifo);
+    }
+    
     return 0;
 }
 

--- a/parsec/scheduling.c
+++ b/parsec/scheduling.c
@@ -395,6 +395,12 @@ int __parsec_schedule_vp(parsec_execution_stream_t* es,
                 }
             }
             target_es = es;
+            if(target_es == &parsec_comm_es) {
+                static int rr = 0;
+                if( rr >= vps[vp]->nb_cores ) rr = 0;
+                target_es = vps[vp]->execution_streams[rr];
+                rr = rr+1 % vps[vp]->nb_cores;
+            }
         }
         ret = __parsec_schedule(target_es, ring, distance);
         if( 0 != ret )

--- a/tests/profiling/Testings.cmake
+++ b/tests/profiling/Testings.cmake
@@ -4,7 +4,7 @@ if(Python_FOUND AND PARSEC_PYTHON_TOOLS AND PARSEC_PROF_TRACE AND MPI_C_FOUND)
   parsec_addtest_cmd(profiling/bw_generate_prof:mp ${MPI_TEST_CMD_LIST} 2 apps/pingpong/bw_test -n 10 -f 10 -l 2097152 -- --mca profile_filename bw  --mca mca_pins task_profiler)
   set_property(TEST profiling/bw_generate_prof:mp PROPERTY FIXTURES_SETUP bw_prof_files)
 
-  set(TMPPYTHONPATH "${PROJECT_BINARY_DIR}/tools/profiling/python/python.test/lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+  set(TMPPYTHONPATH "${PROJECT_BINARY_DIR}/tools/profiling/python/python.test/")
   parsec_addtest_cmd(profiling/bw_generate_hdf5 ${SHM_TEST_CMD_LIST}
     ${Python_EXECUTABLE}
     ${PROJECT_BINARY_DIR}/tools/profiling/python/profile2h5.py --output=bw.h5 bw-0.prof bw-1.prof)

--- a/tools/profiling/python/CMakeLists.txt
+++ b/tools/profiling/python/CMakeLists.txt
@@ -45,7 +45,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/${SETUP_PY}.in
 # location and import the pbt2ptt module.
 add_custom_command(OUTPUT ${OUTPUT}
                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${SRC_PYTHON_SUPPORT} ${CMAKE_CURRENT_BINARY_DIR}
-                   COMMAND ${Python_EXECUTABLE} -m pip install --quiet --prefix=${CMAKE_CURRENT_BINARY_DIR}/python.test .
+                   COMMAND ${Python_EXECUTABLE} -m pip install --quiet --upgrade --target=${CMAKE_CURRENT_BINARY_DIR}/python.test .
                    COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
                    DEPENDS parsec-base ${SRC_PYTHON_SUPPORT})
 add_custom_target(pbt2ptt ALL DEPENDS ${OUTPUT})


### PR DESCRIPTION
I'm creating this PR so the proposed patches are easier to find.

Ideally, I would rebase the patches on top of the current bosilca:topic/tag_registration.

Interesting commits are:
  - partial initialization of parsec_ce requires partial cleanup in parsec_ce_fini for the case where we fini before we use the parsec_ce
  - mempools pointers of the parsec comm ES need to be initialized
  - scheduling object of the parsec comm ES is not set, this must be handled
  - pip install --prefix installs in os-dependent directories, try to use pip install --target instead

With these fixes, all tests pass for parsec on my setup.
